### PR TITLE
[doc] fix installation guide can not return to root path in zh/docs/installation/kubectl-apply.md

### DIFF
--- a/content/zh/docs/installation/kubectl-apply.md
+++ b/content/zh/docs/installation/kubectl-apply.md
@@ -50,7 +50,7 @@ sed "s|__NODE_NAME__|$STORAGE_NODE_NAME|g" `grep __NODE_NAME__ -rl ./templates` 
 kubectl create -f .
 
 # 跳回 Clusterpedia 项目根目录
-cd ../../
+cd ../../../
 ```
 
 ### 安装 Clusterpedia


### PR DESCRIPTION
fix installation guide can not return to root path in zh/docs/installation/kubectl-apply.md

Signed-off-by: hanweisen <hanweisen_yewu@cmss.chinamobile.com>