### PR TITLE
Fix the footer image on home page

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -84,5 +84,5 @@ We do a [Pull Request]("https://github.com/clusterpedia-io/clusterpedia/pulls") 
 {{< blocks/lead color="300" >}}
 <b>Clusterpedia is a <a href="https://www.cncf.io">Cloud Native Computing Foundation</a> sandbox project</b> <br />
 <br />
-<img src="https://landscape.cncf.io/images/right-logo.svg" class="home-cloudnative-logo"/>
+<img src="https://landscape.cncf.io/images/cncf-landscape-horizontal-color.svg" class="home-cloudnative-logo"/>
 {{% /blocks/lead %}}

--- a/content/zh/_index.html
+++ b/content/zh/_index.html
@@ -81,5 +81,5 @@ We do a [Pull Request]("https://github.com/clusterpedia-io/clusterpedia/pulls") 
 {{< blocks/lead color="300" >}}
 <b>Clusterpedia is a <a href="https://www.cncf.io">Cloud Native Computing Foundation</a> sandbox project</b> <br />
 <br />
-<img src="https://landscape.cncf.io/images/right-logo.svg" class="home-cloudnative-logo" />
+<img src="https://landscape.cncf.io/images/cncf-landscape-horizontal-color.svg" class="home-cloudnative-logo" />
 {{% /blocks/lead %}}


### PR DESCRIPTION
Fix the cncf image at footer. The original url doesn't work currently, which might be removed or renamed.